### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, Wisconsin IceCube Particle Astrophysics Center
+Copyright (c) 2014-2024, IceCube Collaboration.
+Contributors are listed at https://github.com/icecube/sndaq/graphs/contributors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Make IceCube Collaboration, not WIPAC, the license holder. Link to contributors list.